### PR TITLE
使非标准玩家名称可以在MCDR使用合适的自定义服务端处理器的情况下由插件正确的对其执行命令

### DIFF
--- a/auto_msg_title/__init__.py
+++ b/auto_msg_title/__init__.py
@@ -152,11 +152,11 @@ def print_title(region_name, player_name):
 
     region_msg = global_data_json[region_name]["msg"]
     if region_msg['title']:
-        rcon_execute(f"title {player_name} title \"{region_msg['title']}\"")
+        rcon_execute(f"title \"{player_name}\" title \"{region_msg['title']}\"")
         if region_msg['subtitle']:
-            rcon_execute(f"title {player_name} subtitle \"{region_msg['subtitle']}\"")
+            rcon_execute(f"title \"{player_name}\" subtitle \"{region_msg['subtitle']}\"")
     if region_msg['actionbar']:
-        rcon_execute(f"title {player_name} actionbar \"{region_msg['actionbar']}\"")
+        rcon_execute(f"title \"{player_name}\" actionbar \"{region_msg['actionbar']}\"")
     if region_msg['msg']:
         for i in region_msg['msg']:
             __mcdr_server.tell(player_name, i)


### PR DESCRIPTION
Fixed unnormal player names can't be parsed.